### PR TITLE
Update 9hentai.lua

### DIFF
--- a/lua/modules/9hentai.lua
+++ b/lua/modules/9hentai.lua
@@ -64,7 +64,7 @@ function Init()
 	m.ID                       = 'f4c518f48eff41efa0929f61fdf93dc6'
 	m.Category                 = 'H-Sites'
 	m.Name                     = '9hentai'
-	m.RootURL                  = 'https://9hentai.com'
+	m.RootURL                  = 'https://9hentai.ru'
 	m.SortedList               = true
 	m.OnGetInfo                = 'GetInfo'
 	m.OnGetPageNumber          = 'GetPageNumber'


### PR DESCRIPTION
9hentai updated their URL to 9hentai.ru. Fixed m.RootURL.