### PR TITLE
Update HentaiNexus.lua

### DIFF
--- a/lua/modules/HentaiNexus.lua
+++ b/lua/modules/HentaiNexus.lua
@@ -61,6 +61,11 @@ function GetPageNumber()
 	local decoded = DecryptMessage(message)
 	x.ParseHTML(decoded)
 	x.XPathStringAll('json(*).pages()', TASK.PageLinks)
+	for i = 0, TASK.PageLinks.Count - 1 do
+		-- Bypass 'i0.wp.com' image CDN to ensure original images are loaded directly from host
+		TASK.PageLinks[i] = TASK.PageLinks[i]:gsub("i%d.wp.com/", "")
+		i = i + 1
+	end
 	return no_error
 end
 


### PR DESCRIPTION
Remove 'i0.wp.com'

Reference : https://github.com/manga-download/hakuneko/blob/d8b40a729a2f1ba247e52f72efb0e77f4e5ee905/src/web/mjs/connectors/templates/WordPressMadara.mjs#L94