### PR TITLE
Update GuyaMoe.lua

### DIFF
--- a/lua/modules/GuyaMoe.lua
+++ b/lua/modules/GuyaMoe.lua
@@ -2,12 +2,9 @@
 -- Auxiliary Functions
 ----------------------------------------------------------------------------------------------------
 
--- Extract slug from script text
+-- Extract slug from URL
 function GetSlug(x)
-	local slug = x.XPathString('//script[contains(., "let slug")]')
-	slug = GetBetween('let slug', ';', slug)
-	slug = slug:gsub('"', ''):gsub('%s*=%s*', '')
-	return slug
+	return string.match(string.gsub(string.gsub(URL, "read", ""), "manga", ""), "/([%a-]+)/")
 end
 
 ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Derive slug from URL instead of script text.
The current GetSlug returns `key.slice(0, separatorIndex)` when called inside GetPageNumber.
GetPageNumber grabs urls like
https://guya.moe/read/manga/Kaguya-Wants-To-Be-Confessed-To/222/
When trying to download this chapter, the current GetSlug finds the line of the html that reads
        `let slug = key.slice(0, separatorIndex);`
can just sidestep the issue by deriving from URL.