### PR TITLE
Fix cloudflare response detection

### DIFF
--- a/lua/websitebypass/cloudflare.lua
+++ b/lua/websitebypass/cloudflare.lua
@@ -189,7 +189,7 @@ function _m.solveChallenge(self, url)
 	local rc = HTTP.ResultCode
 
 	-- firewall blocked
-	if (rc == 403) and body:find('<span class="cf%-error%-code">1020</span>') then
+	if (rc == 403) and body:find('<span.->1020</span>') then
 		LOGGER.SendError('WebsitBypass[cloudflare]: Cloudflare has blocked this request (Code 1020 Detected)\r\n' .. url)
 		return -1
 	end

--- a/lua/websitebypass/cloudflare.lua
+++ b/lua/websitebypass/cloudflare.lua
@@ -202,7 +202,7 @@ function _m.solveChallenge(self, url)
 		return -1
 	end
 	-- new IUAM challenge
-	if ((rc == 429) or (rc == 503)) and body:find('window%._cf_chl_opt={') then
+	if ((rc == 403) or (rc == 429) or (rc == 503)) and body:find('window%._cf_chl_opt={') then
 		if use_webdriver then
 			return self:solveWithWebDriver(url)
 		end


### PR DESCRIPTION
The "error 1020" block page has changed, as have some the response codes when issued a challenge.

Changes keep backwards compatibility for the old block-page and codes (as I don't know if they're still in use).

This does not fix FMD getting detected and blocked by CF, but at least it'll be recognized and logged correctly.