### PR TITLE
Fix Reaper Scans chapters names with release dates.

### DIFF
--- a/lua/modules/Madara.lua
+++ b/lua/modules/Madara.lua
@@ -85,6 +85,11 @@ function Modules.Madara()
 					name = name:match("(.*)" .. rem .. "$")
 					MANGAINFO.ChapterNames.Add(name)
 				end
+			elseif MODULE.ID == 'fb042c961d06479582edb2fa582e3a41' then -- ReaperScans
+				local v for v in x.XPath('//li[contains(@class, "wp-manga-chapter")]').Get() do
+					MANGAINFO.ChapterLinks.Add(x.XPathString('a/@href', v))
+					MANGAINFO.ChapterNames.Add(x.XPathString('a/text()[normalize-space()]', v))
+				end
 			else
 				x.XPathHREFAll('//li[contains(@class, "wp-manga-chapter")]/a', MANGAINFO.ChapterLinks, MANGAINFO.ChapterNames)
 			end


### PR DESCRIPTION
Fix an issue on ReaperScans: Chapters names had the release date included.