### PR TITLE
Update Mangadex.Lua

### DIFF
--- a/lua/modules/MangaDex.lua
+++ b/lua/modules/MangaDex.lua
@@ -364,7 +364,8 @@ function IgnoreChaptersByGroupId(id)
 	local groups = {
 		["4f1de6a2-f0c5-4ac5-bce5-02c7dbb67deb"] = "MangaPlus",
 		["8d8ecf83-8d42-4f8c-add8-60963f9f28d9"] = "Comikey",
-		["5fed0576-8b94-4f9a-b6a7-08eecd69800d"] = "Azuki Manga"
+		["5fed0576-8b94-4f9a-b6a7-08eecd69800d"] = "Azuki Manga",
+		["caa63201-4a17-4b7f-95ff-ed884a2b7e60"] = "INKR Comics"
 	}
 
 	if groups[id] ~= nil then


### PR DESCRIPTION
added another group to ignore as it links to their site and breaks the downloader.