### PR TITLE
Fix GuyaMoe.lua

### DIFF
--- a/lua/modules/GuyaMoe.lua
+++ b/lua/modules/GuyaMoe.lua
@@ -93,7 +93,7 @@ function Init()
 	local m = NewWebsiteModule()
 	m.ID                = '7d12ff8d54d44137adbdf8fbe6f49bee'
 	m.Name              = 'GuyaMoe'
-	m.RootURL           = 'https://guya.moe'
+	m.RootURL           = 'https://guya.cubari.moe'
 	m.Category          = 'English'
 	m.OnGetNameAndLink  = 'GetNameAndLink'
 	m.OnGetInfo         = 'GetInfo'


### PR DESCRIPTION
Updated the Guya url to [guya.cubari.moe](guya.cubari.moe) since guya.cubari always fails (it redirects fine in browser, but not here)