### PR TITLE
ManhwaFreak: Change URL and Fix broken parse function

### DIFF
--- a/lua/modules/ManhwaFreak.lua
+++ b/lua/modules/ManhwaFreak.lua
@@ -53,8 +53,12 @@ function GetInfo()
 	MANGAINFO.Summary   = x.XPathString('//div[@id="summary"]/p')
 
 	for v in x.XPath('//div[@class="chapter-li"]/a').Get() do
-		MANGAINFO.ChapterLinks.Add(v.GetAttribute('href'))
-		MANGAINFO.ChapterNames.Add(x.XPathString('div/div/p[1]', v))
+		-- Skip chapters which are locked
+		local locked = x.XPathString('div/svg/path/@d', v)
+		if locked == nil or locked == '' then
+			MANGAINFO.ChapterLinks.Add(v.GetAttribute('href'))
+			MANGAINFO.ChapterNames.Add(x.XPathString('div/div/p[1]', v))
+		end
 	end
 	MANGAINFO.ChapterLinks.Reverse(); MANGAINFO.ChapterNames.Reverse()
 

--- a/lua/modules/ManhwaFreak.lua
+++ b/lua/modules/ManhwaFreak.lua
@@ -69,7 +69,7 @@ function GetPageNumber()
 	if not HTTP.GET(u) then return net_problem end
 
 	x = CreateTXQuery(HTTP.Document)
-	x.ParseHTML(GetBetween('run(', ');', x.XPathString('//script[contains(., "ts_reader")]')))
+	x.ParseHTML(GetBetween('run(', ', "<script', x.XPathString('//script[contains(., "ts_reader")]')))
 	for v in x.XPath('json(*).sources()[1].images()').Get() do
 		if string.find(v.ToString(), 'ajax') == nil then
 			TASK.PageLinks.Add(v.ToString())

--- a/lua/modules/ManhwaFreak.lua
+++ b/lua/modules/ManhwaFreak.lua
@@ -6,7 +6,7 @@ function Init()
 	local m = NewWebsiteModule()
 	m.ID                       = 'a51ebfb8979045d589cd867c48a095c0'
 	m.Name                     = 'ManhwaFreak'
-	m.RootURL                  = 'https://manhwa-freak.com'
+	m.RootURL                  = 'https://freakcomic.com'
 	m.Category                 = 'English-Scanlation'
 	m.OnGetNameAndLink         = 'GetNameAndLink'
 	m.OnGetInfo                = 'GetInfo'


### PR DESCRIPTION
Several Fixes:
 - Fixed root-url: `manhwa-freak.com` to `freakcomic.com`.
 - Fixed parsing images, code from @jpwong2 in issue #1421.
 - Fixed errors on locked chapters by skipping them.
