### PR TITLE
Update MangaPlus module and proto mapping

### DIFF
--- a/lua/modules/MangaPlus.lua
+++ b/lua/modules/MangaPlus.lua
@@ -42,7 +42,7 @@ protoc:load(readFile(target_file))
 
 -- Get info and chapter list for current manga.
 function GetInfo()
-	local url = MaybeFillHost(API_URL, "/api/title_detail?title_id=" .. URL:gsub("[^%d]",""))
+	local url = MaybeFillHost(API_URL, "/api/title_detailV3?title_id=" .. URL:gsub("[^%d]",""))
 
 	if not HTTP.GET(url) then return net_problem end
 
@@ -68,10 +68,16 @@ function GetInfo()
 	end
 	end
 
-	local first_list = data["success"]["titleDetailView"]["firstChapterList"]
-	local last_list = data["success"]["titleDetailView"]["lastChapterList"]
-	addChapter(first_list)
-	addChapter(last_list)
+	local list_groups = data["success"]["titleDetailView"]["chapterListGroup"]
+
+	if list_groups ~= nil then
+		for _,v in pairs(list_groups) do
+			local first_list = v["firstChapterList"]
+			if first_list ~= nil then addChapter(first_list) end
+			local last_list = v["lastChapterList"]
+			if last_list ~= nil then addChapter(last_list) end
+		end
+	end
 
 	return no_error
 end

--- a/lua/modules/MangaPlus.proto
+++ b/lua/modules/MangaPlus.proto
@@ -275,6 +275,12 @@ message SubscribedTitlesView {
   repeated Title titles = 1;
 }
 
+message ChapterListGroup {
+  repeated Chapter firstChapterList = 2;
+  repeated Chapter midChapterList = 3;
+  repeated Chapter lastChapterList = 4;
+}
+
 message TitleDetailView {
   optional Title title = 1;
   optional string titleImageUrl = 2;
@@ -294,6 +300,7 @@ message TitleDetailView {
   optional int32 rating = 16;
   optional bool chaptersDescending = 17;
   optional uint32 numberOfViews = 18;
+  repeated ChapterListGroup chapterListGroup = 28;
 }
 
 message TitleRankingView {


### PR DESCRIPTION
Addresses https://github.com/dazedcat19/FMD2/issues/1472

This updates the MangaPlus module to use the API v3 (same as the website), and also updates MangaPlus.proto because the data mapping was changed in the API. Tested to be working