### PR TITLE
Update MReader.lua fixing downloading and change pull of chapter list

### DIFF
--- a/lua/modules/MReader.lua
+++ b/lua/modules/MReader.lua
@@ -1,84 +1,140 @@
-----------------------------------------------------------------------------------------------------
--- Module Initialization
-----------------------------------------------------------------------------------------------------
-
 function Init()
-	local m = NewWebsiteModule()
-	m.ID                       = 'd297f1eb6b784ded9b50d3b85cee5276'
-	m.Name                     = 'Mgeko'
-	m.RootURL                  = 'https://www.mgeko.cc'
-	m.Category                 = 'English'
-	m.OnGetDirectoryPageNumber = 'GetDirectoryPageNumber'
-	m.OnGetNameAndLink         = 'GetNameAndLink'
-	m.OnGetInfo                = 'GetInfo'
-	m.OnGetPageNumber          = 'GetPageNumber'
-	m.SortedList               = true
+    local m = NewWebsiteModule()
+    m.ID                       = 'd297f1eb6b784ded9b50d3b85cee5276'
+    m.Name                     = 'MangaNeko'
+    m.RootURL                  = 'https://www.mgeko.cc'
+    m.Category                 = 'English'
+    m.OnGetDirectoryPageNumber = 'GetDirectoryPageNumber'
+    m.OnGetNameAndLink         = 'GetNameAndLink'
+    m.OnGetInfo                = 'GetInfo'
+    m.OnGetPageNumber          = 'GetPageNumber'
+    m.SortedList               = true
+    return m
 end
 
-----------------------------------------------------------------------------------------------------
--- Local Constants
-----------------------------------------------------------------------------------------------------
+local DirectoryPagination = '/browse-comics/?results=%s&filter=New'
 
-DirectoryPagination = '/browse-comics/?results=%s&filter=New'
+local function userDataToString(userData)
+    if type(userData) == "userdata" then
+        if userData.ToString then
+            return userData:ToString()
+        elseif userData.Read then
+            return userData:Read(userData.Size)
+        else
+            return tostring(userData)
+        end
+    else
+        return tostring(userData)
+    end
+end
 
-----------------------------------------------------------------------------------------------------
--- Event Functions
-----------------------------------------------------------------------------------------------------
-
--- Get the page count of the manga list of the current website.
 function GetDirectoryPageNumber()
-	local u = MODULE.RootURL .. DirectoryPagination:format('1')
-
-	if not HTTP.GET(u) then return net_problem end
-
-	PAGENUMBER = tonumber(CreateTXQuery(HTTP.Document).XPathString('(//ul[@class="pagination"])[1]/li[last()-1]')) or 1
-
-	return no_error
+    local u = MODULE.RootURL .. DirectoryPagination:format('1')
+    if not HTTP.GET(u) then 
+        return net_problem 
+    end
+    local documentString = userDataToString(HTTP.Document)
+    local query = CreateTXQuery(documentString)
+    local pageNumberString = query.XPathString('(//ul[@class="pagination"])[1]/li[last()-1]')
+    PAGENUMBER = tonumber(pageNumberString) or 1
+    return no_error
 end
 
--- Get links and names from the manga list of the current website.
 function GetNameAndLink()
-	local v, x = nil
-	local u = MODULE.RootURL .. DirectoryPagination:format((URL + 1))
-
-	if not HTTP.GET(u) then return net_problem end
-
-	CreateTXQuery(HTTP.Document).XPathHREFTitleAll('//li[@class="novel-item"]/a', LINKS, NAMES)
-
-	return no_error
+    local u = MODULE.RootURL .. DirectoryPagination:format(tostring(URL + 1))
+    if not HTTP.GET(u) then 
+        return net_problem 
+    end
+    local documentString = userDataToString(HTTP.Document)
+    local query = CreateTXQuery(documentString)
+    query.XPathHREFTitleAll('//li[@class="novel-item"]/a', LINKS, NAMES)
+    return no_error
 end
 
--- Get info and chapter list for current manga.
 function GetInfo()
-	local v, x = nil
-	local u = MaybeFillHost(MODULE.RootURL, URL)
+    local u = MaybeFillHost(MODULE.RootURL, URL)
+    if not HTTP.GET(u) then 
+        return net_problem
+    end
+    local query = CreateTXQuery(HTTP.Document)
+    
+    MANGAINFO.Title = query.XPathString('//h1[@class="novel-title text2row"]')
+    
+    -- Improved cover image extraction
+    local coverLink = query.XPathString('//figure[@class="cover"]//img/@data-src')
+    if not coverLink or coverLink == '' then
+        coverLink = query.XPathString('//figure[@class="cover"]//img/@src')
+    end
+    
+    if coverLink and coverLink ~= '' then
+        coverLink = coverLink:gsub('%?.*$', '')
+        coverLink = coverLink:gsub('%%', '%%%%')
+        if not coverLink:match('^https?://') then
+            coverLink = MODULE.RootURL .. coverLink
+        end
+        MANGAINFO.CoverLink = coverLink
+    end
+    
+    MANGAINFO.Authors   = query.XPathString('//div[@class="author"]/a/span[@itemprop="author"]')
+    MANGAINFO.Genres    = query.XPathStringAll('//div[@class="categories"]/ul/li/a')
+    MANGAINFO.Status    = query.XPathString('//div[@class="header-stats"]//strong[contains(@class, "ongoing") or contains(@class, "completed")]')
+    MANGAINFO.Summary   = query.XPathString('//p[@class="description"]')
 
-	if not HTTP.GET(u) then return net_problem end
+    -- Check for "All Chapters" link
+    local allChaptersLink = query.XPathString('//a[contains(@href, "/all-chapters/")]/@href')
+    
+    -- If "All Chapters" link exists, use it to get chapters
+    if allChaptersLink and allChaptersLink ~= '' then
+        if HTTP.GET(MaybeFillHost(MODULE.RootURL, allChaptersLink)) then
+            query = CreateTXQuery(HTTP.Document)
+        end
+    end
 
-	x = CreateTXQuery(HTTP.Document)
-	MANGAINFO.Title     = x.XPathString('//h1[contains(@class, "title")]')
-	MANGAINFO.CoverLink = x.XPathString('//figure[@class="cover"]/img/@data-src')
-	MANGAINFO.Authors   = x.XPathString('//span[@itemprop="author"]')
-	MANGAINFO.Genres    = x.XPathStringAll('//div[@class="categories"]//a')
-	MANGAINFO.Status    = MangaInfoStatusIfPos(x.XPathString('//span[contains(., "Status")]/parent::*'))
-	MANGAINFO.Summary   = x.XPathString('//p[@class="description"]')
+    -- Get chapters
+    local chapters = query.XPath('//ul[@class="chapter-list"]/li/a')
+    if chapters.Count == 0 then
+        -- If no chapters found, try a different XPath
+        chapters = query.XPath('//ul[contains(@class, "chapter-list")]/li/a')
+    end
 
-	for v in x.XPath('//ul[@class="chapter-list"]//a').Get() do
-		MANGAINFO.ChapterNames.Add(x.XPathString('strong/replace(., "-eng-li", " [EN]")', v))
-		MANGAINFO.ChapterLinks.Add(v.GetAttribute('href'))
-	end
-	MANGAINFO.ChapterLinks.Reverse(); MANGAINFO.ChapterNames.Reverse()
+    for v in chapters.Get() do
+        local chapterTitle = query.XPathString('.//span[contains(@class, "chapter-title")] | .//strong[@class="chapter-title"]', v)
+        local chapterLink = v.GetAttribute('href')
+        if chapterTitle and chapterTitle ~= '' and chapterLink and chapterLink ~= '' then
+            -- Extract chapter number
+            local chapterNumber = chapterTitle:match("Chapter (%d+)")
+            if chapterNumber then
+                local standardizedTitle = string.format("Chapter %s", chapterNumber)
+                local chapterID = chapterLink:match("/chapter%-([%d%-]+)")
+                if chapterID then
+                    standardizedTitle = string.format("%s [%s]", standardizedTitle, chapterID)
+                end
+                MANGAINFO.ChapterNames.Add(standardizedTitle)
+                MANGAINFO.ChapterLinks.Add(chapterLink)
+            else
+                -- If no chapter number found, use the original title
+                MANGAINFO.ChapterNames.Add(chapterTitle)
+                MANGAINFO.ChapterLinks.Add(chapterLink)
+            end
+        end
+    end
 
-	return no_error
+    -- Reverse chapter order if needed and if chapters were found
+    if MANGAINFO.ChapterLinks.Count > 0 and MANGAINFO.ChapterLinks.Reverse then
+        MANGAINFO.ChapterLinks.Reverse()
+        MANGAINFO.ChapterNames.Reverse()
+    end
+
+    return no_error
 end
 
--- Get the page count for the current chapter.
 function GetPageNumber()
-	local u = MaybeFillHost(MODULE.RootURL, URL)
-
-	if not HTTP.GET(u) then return net_problem end
-
-	CreateTXQuery(HTTP.Document).XPathStringAll('//section[@class="page-in content-wrap"]//center/div/img/@src', TASK.PageLinks)
-
-	return no_error
+    local u = MaybeFillHost(MODULE.RootURL, URL)
+    if not HTTP.GET(u) then 
+        return net_problem 
+    end
+    local documentString = userDataToString(HTTP.Document)
+    local query = CreateTXQuery(documentString)
+    query.XPathStringAll('//section[@class="page-in content-wrap"]//center/div/img/@src', TASK.PageLinks)
+    return no_error
 end

--- a/lua/modules/MReader.lua
+++ b/lua/modules/MReader.lua
@@ -1,140 +1,88 @@
+----------------------------------------------------------------------------------------------------
+-- Module Initialization
+----------------------------------------------------------------------------------------------------
+
 function Init()
-    local m = NewWebsiteModule()
-    m.ID                       = 'd297f1eb6b784ded9b50d3b85cee5276'
-    m.Name                     = 'MangaNeko'
-    m.RootURL                  = 'https://www.mgeko.cc'
-    m.Category                 = 'English'
-    m.OnGetDirectoryPageNumber = 'GetDirectoryPageNumber'
-    m.OnGetNameAndLink         = 'GetNameAndLink'
-    m.OnGetInfo                = 'GetInfo'
-    m.OnGetPageNumber          = 'GetPageNumber'
-    m.SortedList               = true
-    return m
+	local m = NewWebsiteModule()
+	m.ID                       = 'd297f1eb6b784ded9b50d3b85cee5276'
+	m.Name                     = 'MangaGeko'
+	m.RootURL                  = 'https://www.mgeko.cc'
+	m.Category                 = 'English'
+	m.OnGetDirectoryPageNumber = 'GetDirectoryPageNumber'
+	m.OnGetNameAndLink         = 'GetNameAndLink'
+	m.OnGetInfo                = 'GetInfo'
+	m.OnGetPageNumber          = 'GetPageNumber'
+	m.SortedList               = true
 end
 
-local DirectoryPagination = '/browse-comics/?results=%s&filter=New'
+----------------------------------------------------------------------------------------------------
+-- Local Constants
+----------------------------------------------------------------------------------------------------
 
-local function userDataToString(userData)
-    if type(userData) == "userdata" then
-        if userData.ToString then
-            return userData:ToString()
-        elseif userData.Read then
-            return userData:Read(userData.Size)
-        else
-            return tostring(userData)
-        end
-    else
-        return tostring(userData)
-    end
-end
+DirectoryPagination = '/browse-comics/?results=%s&filter=New'
 
+----------------------------------------------------------------------------------------------------
+-- Event Functions
+----------------------------------------------------------------------------------------------------
+
+-- Get the page count of the manga list of the current website.
 function GetDirectoryPageNumber()
-    local u = MODULE.RootURL .. DirectoryPagination:format('1')
-    if not HTTP.GET(u) then 
-        return net_problem 
-    end
-    local documentString = userDataToString(HTTP.Document)
-    local query = CreateTXQuery(documentString)
-    local pageNumberString = query.XPathString('(//ul[@class="pagination"])[1]/li[last()-1]')
-    PAGENUMBER = tonumber(pageNumberString) or 1
-    return no_error
+	local u = MODULE.RootURL .. DirectoryPagination:format(1)
+
+	if not HTTP.GET(u) then return net_problem end
+
+	PAGENUMBER = tonumber(CreateTXQuery(HTTP.Document).XPathString('(//span[@class="mg-pagination-last"])[1]'):match('(%d+)$')) or 1
+	print(PAGENUMBER)
+
+	return no_error
 end
 
+-- Get links and names from the manga list of the current website.
 function GetNameAndLink()
-    local u = MODULE.RootURL .. DirectoryPagination:format(tostring(URL + 1))
-    if not HTTP.GET(u) then 
-        return net_problem 
-    end
-    local documentString = userDataToString(HTTP.Document)
-    local query = CreateTXQuery(documentString)
-    query.XPathHREFTitleAll('//li[@class="novel-item"]/a', LINKS, NAMES)
-    return no_error
+	local v, x = nil
+	local u = MODULE.RootURL .. DirectoryPagination:format((URL + 1))
+
+	if not HTTP.GET(u) then return net_problem end
+
+	CreateTXQuery(HTTP.Document).XPathHREFTitleAll('//li[@class="novel-item"]/a', LINKS, NAMES)
+
+	return no_error
 end
 
+-- Get info and chapter list for current manga.
 function GetInfo()
-    local u = MaybeFillHost(MODULE.RootURL, URL)
-    if not HTTP.GET(u) then 
-        return net_problem
-    end
-    local query = CreateTXQuery(HTTP.Document)
-    
-    MANGAINFO.Title = query.XPathString('//h1[@class="novel-title text2row"]')
-    
-    -- Improved cover image extraction
-    local coverLink = query.XPathString('//figure[@class="cover"]//img/@data-src')
-    if not coverLink or coverLink == '' then
-        coverLink = query.XPathString('//figure[@class="cover"]//img/@src')
-    end
-    
-    if coverLink and coverLink ~= '' then
-        coverLink = coverLink:gsub('%?.*$', '')
-        coverLink = coverLink:gsub('%%', '%%%%')
-        if not coverLink:match('^https?://') then
-            coverLink = MODULE.RootURL .. coverLink
-        end
-        MANGAINFO.CoverLink = coverLink
-    end
-    
-    MANGAINFO.Authors   = query.XPathString('//div[@class="author"]/a/span[@itemprop="author"]')
-    MANGAINFO.Genres    = query.XPathStringAll('//div[@class="categories"]/ul/li/a')
-    MANGAINFO.Status    = query.XPathString('//div[@class="header-stats"]//strong[contains(@class, "ongoing") or contains(@class, "completed")]')
-    MANGAINFO.Summary   = query.XPathString('//p[@class="description"]')
+	local v, x = nil
+	local u = MaybeFillHost(MODULE.RootURL, URL)
 
-    -- Check for "All Chapters" link
-    local allChaptersLink = query.XPathString('//a[contains(@href, "/all-chapters/")]/@href')
-    
-    -- If "All Chapters" link exists, use it to get chapters
-    if allChaptersLink and allChaptersLink ~= '' then
-        if HTTP.GET(MaybeFillHost(MODULE.RootURL, allChaptersLink)) then
-            query = CreateTXQuery(HTTP.Document)
-        end
-    end
+	if not HTTP.GET(u) then return net_problem end
 
-    -- Get chapters
-    local chapters = query.XPath('//ul[@class="chapter-list"]/li/a')
-    if chapters.Count == 0 then
-        -- If no chapters found, try a different XPath
-        chapters = query.XPath('//ul[contains(@class, "chapter-list")]/li/a')
-    end
+	x = CreateTXQuery(HTTP.Document)
+	MANGAINFO.Title     = x.XPathString('//h1[contains(@class, "title")]')
+	MANGAINFO.CoverLink = x.XPathString('//figure[@class="cover"]/img/@data-src')
+	MANGAINFO.Authors   = x.XPathString('//span[@itemprop="author"]')
+	MANGAINFO.Genres    = x.XPathStringAll('//div[@class="categories"]//a')
+	MANGAINFO.Status    = MangaInfoStatusIfPos(x.XPathString('//span[contains(., "Status")]/parent::*'))
+	MANGAINFO.Summary   = x.XPathString('//p[@class="description"]')
 
-    for v in chapters.Get() do
-        local chapterTitle = query.XPathString('.//span[contains(@class, "chapter-title")] | .//strong[@class="chapter-title"]', v)
-        local chapterLink = v.GetAttribute('href')
-        if chapterTitle and chapterTitle ~= '' and chapterLink and chapterLink ~= '' then
-            -- Extract chapter number
-            local chapterNumber = chapterTitle:match("Chapter (%d+)")
-            if chapterNumber then
-                local standardizedTitle = string.format("Chapter %s", chapterNumber)
-                local chapterID = chapterLink:match("/chapter%-([%d%-]+)")
-                if chapterID then
-                    standardizedTitle = string.format("%s [%s]", standardizedTitle, chapterID)
-                end
-                MANGAINFO.ChapterNames.Add(standardizedTitle)
-                MANGAINFO.ChapterLinks.Add(chapterLink)
-            else
-                -- If no chapter number found, use the original title
-                MANGAINFO.ChapterNames.Add(chapterTitle)
-                MANGAINFO.ChapterLinks.Add(chapterLink)
-            end
-        end
-    end
+	if HTTP.GET(u .. '/all-chapters/') then
+		x = CreateTXQuery(HTTP.Document)
+		for v in x.XPath('//ul[@class="chapter-list"]//a').Get() do
+			MANGAINFO.ChapterLinks.Add(v.GetAttribute('href'))
+			MANGAINFO.ChapterNames.Add('Chapter ' .. x.XPathString('strong/replace(., "-eng-li", "")', v))
+		end
+	end
+	MANGAINFO.ChapterLinks.Reverse(); MANGAINFO.ChapterNames.Reverse()
 
-    -- Reverse chapter order if needed and if chapters were found
-    if MANGAINFO.ChapterLinks.Count > 0 and MANGAINFO.ChapterLinks.Reverse then
-        MANGAINFO.ChapterLinks.Reverse()
-        MANGAINFO.ChapterNames.Reverse()
-    end
-
-    return no_error
+	return no_error
 end
 
+-- Get the page count for the current chapter.
 function GetPageNumber()
-    local u = MaybeFillHost(MODULE.RootURL, URL)
-    if not HTTP.GET(u) then 
-        return net_problem 
-    end
-    local documentString = userDataToString(HTTP.Document)
-    local query = CreateTXQuery(documentString)
-    query.XPathStringAll('//section[@class="page-in content-wrap"]//center/div/img/@src', TASK.PageLinks)
-    return no_error
+	local u = MaybeFillHost(MODULE.RootURL, URL)
+
+	if not HTTP.GET(u) then return net_problem end
+
+	CreateTXQuery(HTTP.Document).XPathStringAll('//section[@class="page-in content-wrap"]//center/div/img/@src', TASK.PageLinks)
+
+	return no_error
 end


### PR DESCRIPTION
I found that even after updating the url download was still broken so this update fixes that.

On the website there are two listed areas of chapters. the first, and the one used until now, pulled from the most recent 50 chapters. What this update does is instead pulls from the all chapters listing. that way of any decent length you do not have to download it 2 separate times and move the chapters from the N/A folder.


There may be issues. for example for some reason i dont see the module in the drop down anymore and dont know how to fix.