### PR TITLE
Fixed missing episode title for Manta

### DIFF
--- a/lua/modules/Manta.lua
+++ b/lua/modules/Manta.lua
@@ -58,7 +58,13 @@ function GetInfo()
 
 	for v in x.XPath('json(*).data.episodes()[lockData/state="100" or lockData/state="110" or lockData/state="130" or lockData/state="140"]').Get() do
 		MANGAINFO.ChapterLinks.Add(v.GetProperty('id').ToString())
-		MANGAINFO.ChapterNames.Add(x.XPathString('data/title', v))
+
+		local episodeTitle = x.XPathString('data/title', v)
+		if episodeTitle == '' then
+			episodeTitle = 'Episode ' .. x.XPathString('ord', v)
+		end
+
+		MANGAINFO.ChapterNames.Add(episodeTitle)
 	end
 
 	return no_error


### PR DESCRIPTION
Sometimes episode data does not include the episode title. This PR fixes this problem by using the episode number.